### PR TITLE
use $GOPATH and others directly instead of config

### DIFF
--- a/lib/go-oracle.coffee
+++ b/lib/go-oracle.coffee
@@ -1,10 +1,6 @@
 GoOracleView = require './go-oracle-view'
 
 module.exports =
-  configDefaults:
-    goPath: ""
-    oraclePath: "$GOPATH/bin/oracle"
-
   goOracleView: null
 
   activate: (state) ->


### PR DESCRIPTION
Previously it would only set $GOPATH for the process, which would
effectively undefine $PATH and other important envs.

I think it makes more sense to just use the environment that Atom
started in, and just shell out to `oracle`.

Also improved debuggability when shelling out by capturing stderr/exit
code and logging it on failure.
