### PR TITLE
oracle needs access to the go tool

### DIFF
--- a/lib/go-oracle.coffee
+++ b/lib/go-oracle.coffee
@@ -5,6 +5,9 @@ module.exports =
     goPath:
       type: 'string'
       default: ''
+    goRoot:
+      type: 'string'
+      default: ''
     oraclePath:
       type: 'string'
       default: '$GOPATH/bin/oracle'

--- a/lib/oracle-command.coffee
+++ b/lib/oracle-command.coffee
@@ -10,7 +10,8 @@ class OracleCommand
     [startOffset, endOffset] = @getPosition()
 
     gopath = @goPath()
-    env = {"GOPATH": gopath}
+    goroot = @goRoot()
+    env = {"GOPATH": gopath, "PATH": gopath+ "bin:" + goroot + "bin:" + process.env.PATH}
     oracleCmd = atom.config.get('go-oracle.oraclePath')
     oracleCmd = oracleCmd.replace(/^\$GOPATH\//i, gopath)
 
@@ -69,3 +70,11 @@ class OracleCommand
     gopath = gopathEnv if gopathEnv? and gopathEnv isnt ''
     gopath = gopathConfig if gopath is ''
     return gopath + '/'
+
+  goRoot: ->
+    goroot = ''
+    gorootEnv = process.env.GOROOT
+    gorootConfig = atom.config.get('go-oracle.goRoot')
+    goroot = gorootEnv if gorootEnv? and gorootEnv isnt ''
+    goroot = gorootConfig if goroot is ''
+    return goroot + '/'


### PR DESCRIPTION
I can't figure out the "right" way to add this into GUI apps (how I use
Atom) on OSX 10.10.4. I've tried several ways (launchctl, various files
in /etc), etc to no avail. So I punted with this.
